### PR TITLE
feat: refresh dashboards with Cargills branding

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,34 +1,53 @@
-import { BrowserRouter as Router, Routes, Route, Link } from "react-router-dom";
+import { BrowserRouter as Router, Routes, Route, NavLink } from "react-router-dom";
 import Analytics from "./pages/Analytics";
 import Customers from "./pages/Customers";
 import Products from "./pages/Products";
 import Transactions from "./pages/Transactions";
 import Offers from "./pages/Offers";
 import Stores from "./pages/Stores";
+import "./styles.css";
 
 function App() {
+  const navLinks = [
+    { to: "/analytics", label: "Analytics" },
+    { to: "/customers", label: "Customers" },
+    { to: "/products", label: "Products" },
+    { to: "/transactions", label: "Transactions" },
+    { to: "/offers", label: "Offers" },
+    { to: "/stores", label: "Stores" },
+  ];
+
   return (
     <Router>
-      <div>
-        <nav>
-          <Link to="/analytics">Analytics</Link> |{" "}
-          <Link to="/customers">Customers</Link> |{" "}
-          <Link to="/products">Products</Link> |{" "}
-          <Link to="/transactions">Transactions</Link> |{" "}
-          <Link to="/offers">Offers</Link> |{" "}
-          <Link to="/stores">Stores</Link>
-        </nav>
-        <hr />
-
-        <Routes>
-          <Route path="/" element={<Analytics />} />
-          <Route path="/analytics" element={<Analytics />} />
-          <Route path="/customers" element={<Customers />} />
-          <Route path="/products" element={<Products />} />
-          <Route path="/transactions" element={<Transactions />} />
-          <Route path="/offers" element={<Offers />} />
-          <Route path="/stores" element={<Stores />} />
-        </Routes>
+      <div className="app-container">
+        <aside className="sidebar">
+          <img src="/cargills-logo.png" alt="Cargills Logo" className="h-12 mx-auto my-4" />
+          <h1 className="sidebar-title">Cargills Insights</h1>
+          <nav className="sidebar-nav">
+            {navLinks.map((link) => (
+              <NavLink
+                key={link.to}
+                to={link.to}
+                className={({ isActive }) =>
+                  ["nav-link", isActive ? "active" : null].filter(Boolean).join(" ")
+                }
+              >
+                {link.label}
+              </NavLink>
+            ))}
+          </nav>
+        </aside>
+        <main className="main-content">
+          <Routes>
+            <Route path="/" element={<Analytics />} />
+            <Route path="/analytics" element={<Analytics />} />
+            <Route path="/customers" element={<Customers />} />
+            <Route path="/products" element={<Products />} />
+            <Route path="/transactions" element={<Transactions />} />
+            <Route path="/offers" element={<Offers />} />
+            <Route path="/stores" element={<Stores />} />
+          </Routes>
+        </main>
       </div>
     </Router>
   );

--- a/src/components/CustomerDashboard.jsx
+++ b/src/components/CustomerDashboard.jsx
@@ -94,82 +94,100 @@ function CustomerDashboard() {
     });
   };
 
-  if (loading) {
-    return <p>Loading customers...</p>;
-  }
-
   return (
-    <div>
-      <h2>Customer List</h2>
-      {customers.length === 0 ? (
-        <p>No customers found.</p>
-      ) : (
-        <ul>
-          {customers.map(c => (
-            <li key={c._id}>
-              <strong>{c.name}</strong> — {c.customer_id} ({c.loyalty_tier})
-              <button onClick={() => handleEdit(c)}>Edit</button>
-              <button onClick={() => handleDelete(c._id)}>Delete</button>
-            </li>
-          ))}
-        </ul>
-      )}
+    <div className="dashboard-grid">
+      <section className="dashboard-section">
+        <h2 className="section-title">Customer List</h2>
+        <div className="card">
+          {loading ? (
+            <p className="empty-state">Loading customers...</p>
+          ) : customers.length === 0 ? (
+            <p className="empty-state">No customers found.</p>
+          ) : (
+            <ul className="data-list">
+              {customers.map(c => (
+                <li key={c._id} className="data-card">
+                  <div>
+                    <span className="item-title">{c.name}</span>
+                    <p className="item-meta">ID: {c.customer_id} • Tier: {c.loyalty_tier}</p>
+                    <p className="item-meta">Location: {c.location} • Household Size: {c.household_size}</p>
+                  </div>
+                  <div className="actions">
+                    <button type="button" className="btn edit-btn" onClick={() => handleEdit(c)}>Edit</button>
+                    <button type="button" className="btn delete-btn" onClick={() => handleDelete(c._id)}>Delete</button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </section>
 
-      <h2>{formData._id ? "Edit Customer" : "Add New Customer"}</h2>
-      <form onSubmit={handleSubmit}>
-        <input
-          type="text"
-          name="customer_id"
-          placeholder="Customer ID"
-          value={formData.customer_id}
-          onChange={handleChange}
-          required
-        />
-        <input
-          type="text"
-          name="name"
-          placeholder="Name"
-          value={formData.name}
-          onChange={handleChange}
-          required
-        />
-        <input
-          type="number"
-          name="age"
-          placeholder="Age"
-          value={formData.age}
-          onChange={handleChange}
-          required
-        />
-        <input
-          type="text"
-          name="loyalty_tier"
-          placeholder="Loyalty Tier"
-          value={formData.loyalty_tier}
-          onChange={handleChange}
-          required
-        />
-        <input
-          type="text"
-          name="location"
-          placeholder="Location"
-          value={formData.location}
-          onChange={handleChange}
-          required
-        />
-        <input
-          type="number"
-          name="household_size"
-          placeholder="Household Size"
-          value={formData.household_size}
-          onChange={handleChange}
-          required
-        />
-        <button type="submit">
-          {formData._id ? "Update Customer" : "Add Customer"}
-        </button>
-        {formData._id && <button onClick={resetForm}>Cancel</button>}
-      </form>
+      <section className="dashboard-section">
+        <h2 className="section-title">{formData._id ? "Edit Customer" : "Add New Customer"}</h2>
+        <div className="card">
+          <form onSubmit={handleSubmit} className="form-grid">
+            <input
+              type="text"
+              name="customer_id"
+              placeholder="Customer ID"
+              value={formData.customer_id}
+              onChange={handleChange}
+              required
+            />
+            <input
+              type="text"
+              name="name"
+              placeholder="Name"
+              value={formData.name}
+              onChange={handleChange}
+              required
+            />
+            <input
+              type="number"
+              name="age"
+              placeholder="Age"
+              value={formData.age}
+              onChange={handleChange}
+              required
+            />
+            <input
+              type="text"
+              name="loyalty_tier"
+              placeholder="Loyalty Tier"
+              value={formData.loyalty_tier}
+              onChange={handleChange}
+              required
+            />
+            <input
+              type="text"
+              name="location"
+              placeholder="Location"
+              value={formData.location}
+              onChange={handleChange}
+              required
+            />
+            <input
+              type="number"
+              name="household_size"
+              placeholder="Household Size"
+              value={formData.household_size}
+              onChange={handleChange}
+              required
+            />
+            <div className="actions">
+              <button type="submit" className="btn primary-btn">
+                {formData._id ? "Update Customer" : "Add Customer"}
+              </button>
+              {formData._id && (
+                <button type="button" className="btn secondary-btn" onClick={resetForm}>
+                  Cancel
+                </button>
+              )}
+            </div>
+          </form>
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/components/OfferDashboard.jsx
+++ b/src/components/OfferDashboard.jsx
@@ -90,32 +90,87 @@ function OfferDashboard() {
   };
 
   return (
-    <div>
-      <h2>Offers</h2>
-      {offers.length === 0 ? (
-        <p>No offers found.</p>
-      ) : (
-        <ul>
-          {offers.map(o => (
-            <li key={o._id}>
-              {o.offer_id} — {o.description} — Valid until: {o.valid_until}
-              <button onClick={() => handleEdit(o)}>Edit</button>
-              <button onClick={() => handleDelete(o._id)}>Delete</button>
-            </li>
-          ))}
-        </ul>
-      )}
+    <div className="dashboard-grid">
+      <section className="dashboard-section">
+        <h2 className="section-title">Active Offers</h2>
+        <div className="card">
+          {offers.length === 0 ? (
+            <p className="empty-state">No offers found.</p>
+          ) : (
+            <ul className="data-list">
+              {offers.map(o => (
+                <li key={o._id} className="data-card">
+                  <div>
+                    <span className="item-title">{o.offer_id}</span>
+                    <p className="item-meta">{o.description}</p>
+                    <p className="item-meta">Valid until: {o.valid_until}</p>
+                    <p className="item-meta">Eligible Tiers: {Array.isArray(o.eligible_tiers) ? o.eligible_tiers.join(", ") : o.eligible_tiers}</p>
+                    <p className="item-meta">Categories: {Array.isArray(o.category_scope) ? o.category_scope.join(", ") : o.category_scope}</p>
+                  </div>
+                  <div className="actions">
+                    <button type="button" className="btn edit-btn" onClick={() => handleEdit(o)}>Edit</button>
+                    <button type="button" className="btn delete-btn" onClick={() => handleDelete(o._id)}>Delete</button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </section>
 
-      <h3>{formData._id ? "Edit Offer" : "Add Offer"}</h3>
-      <form onSubmit={handleSubmit}>
-        <input type="text" name="offer_id" placeholder="Offer ID" value={formData.offer_id} onChange={handleChange} required />
-        <input type="text" name="description" placeholder="Description" value={formData.description} onChange={handleChange} required />
-        <input type="date" name="valid_until" placeholder="Valid Until" value={formData.valid_until} onChange={handleChange} required />
-        <input type="text" name="eligible_tiers" placeholder="Eligible Tiers (comma-separated)" value={formData.eligible_tiers} onChange={handleChange} required />
-        <input type="text" name="category_scope" placeholder="Category Scope (comma-separated)" value={formData.category_scope} onChange={handleChange} required />
-        <button type="submit">{formData._id ? "Update Offer" : "Add Offer"}</button>
-        {formData._id && <button type="button" onClick={resetForm}>Cancel</button>}
-      </form>
+      <section className="dashboard-section">
+        <h2 className="section-title">{formData._id ? "Edit Offer" : "Add Offer"}</h2>
+        <div className="card">
+          <form onSubmit={handleSubmit} className="form-grid">
+            <input
+              type="text"
+              name="offer_id"
+              placeholder="Offer ID"
+              value={formData.offer_id}
+              onChange={handleChange}
+              required
+            />
+            <input
+              type="text"
+              name="description"
+              placeholder="Description"
+              value={formData.description}
+              onChange={handleChange}
+              required
+            />
+            <input
+              type="date"
+              name="valid_until"
+              placeholder="Valid Until"
+              value={formData.valid_until}
+              onChange={handleChange}
+              required
+            />
+            <input
+              type="text"
+              name="eligible_tiers"
+              placeholder="Eligible Tiers (comma-separated)"
+              value={formData.eligible_tiers}
+              onChange={handleChange}
+              required
+            />
+            <input
+              type="text"
+              name="category_scope"
+              placeholder="Category Scope (comma-separated)"
+              value={formData.category_scope}
+              onChange={handleChange}
+              required
+            />
+            <div className="actions">
+              <button type="submit" className="btn primary-btn">{formData._id ? "Update Offer" : "Add Offer"}</button>
+              {formData._id && (
+                <button type="button" className="btn secondary-btn" onClick={resetForm}>Cancel</button>
+              )}
+            </div>
+          </form>
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/components/ProductDashboard.jsx
+++ b/src/components/ProductDashboard.jsx
@@ -92,66 +92,84 @@ function ProductDashboard() {
   };
 
   return (
-    <div>
-      <h2>Products</h2>
-      {products.length === 0 ? (
-        <p>No products found.</p>
-      ) : (
-        <ul>
-          {products.map(p => (
-            <li key={p._id}>
-              {p.product_id} — {p.name} ({p.category}) - {p.price} {p.currency}
-              <button onClick={() => handleEdit(p)}>Edit</button>
-              <button onClick={() => handleDelete(p._id)}>Delete</button>
-            </li>
-          ))}
-        </ul>
-      )}
+    <div className="dashboard-grid">
+      <section className="dashboard-section">
+        <h2 className="section-title">Product Catalogue</h2>
+        <div className="card">
+          {products.length === 0 ? (
+            <p className="empty-state">No products found.</p>
+          ) : (
+            <ul className="data-list">
+              {products.map(p => (
+                <li key={p._id} className="data-card">
+                  <div>
+                    <span className="item-title">{p.name}</span>
+                    <p className="item-meta">ID: {p.product_id} • Category: {p.category}</p>
+                    <p className="item-meta">Price: {p.price} {p.currency} • Tags: {p.tags?.join ? p.tags.join(", ") : p.tags}</p>
+                  </div>
+                  <div className="actions">
+                    <button type="button" className="btn edit-btn" onClick={() => handleEdit(p)}>Edit</button>
+                    <button type="button" className="btn delete-btn" onClick={() => handleDelete(p._id)}>Delete</button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </section>
 
-      <h3>{formData._id ? "Edit Product" : "Add Product"}</h3>
-      <form onSubmit={handleSubmit}>
-        <input
-          type="text"
-          name="product_id"
-          placeholder="Product ID"
-          value={formData.product_id}
-          onChange={handleChange}
-          required
-        />
-        <input
-          type="text"
-          name="name"
-          placeholder="Name"
-          value={formData.name}
-          onChange={handleChange}
-          required
-        />
-        <input
-          type="text"
-          name="category"
-          placeholder="Category"
-          value={formData.category}
-          onChange={handleChange}
-          required
-        />
-        <input
-          type="number"
-          name="price"
-          placeholder="Price"
-          value={formData.price}
-          onChange={handleChange}
-          required
-        />
-        <input
-          type="text"
-          name="tags"
-          placeholder="Tags (comma-separated)"
-          value={formData.tags}
-          onChange={handleChange}
-        />
-        <button type="submit">{formData._id ? "Update Product" : "Add Product"}</button>
-        {formData._id && <button type="button" onClick={resetForm}>Cancel</button>}
-      </form>
+      <section className="dashboard-section">
+        <h2 className="section-title">{formData._id ? "Edit Product" : "Add Product"}</h2>
+        <div className="card">
+          <form onSubmit={handleSubmit} className="form-grid">
+            <input
+              type="text"
+              name="product_id"
+              placeholder="Product ID"
+              value={formData.product_id}
+              onChange={handleChange}
+              required
+            />
+            <input
+              type="text"
+              name="name"
+              placeholder="Name"
+              value={formData.name}
+              onChange={handleChange}
+              required
+            />
+            <input
+              type="text"
+              name="category"
+              placeholder="Category"
+              value={formData.category}
+              onChange={handleChange}
+              required
+            />
+            <input
+              type="number"
+              name="price"
+              placeholder="Price"
+              value={formData.price}
+              onChange={handleChange}
+              required
+            />
+            <input
+              type="text"
+              name="tags"
+              placeholder="Tags (comma-separated)"
+              value={formData.tags}
+              onChange={handleChange}
+            />
+            <div className="actions">
+              <button type="submit" className="btn primary-btn">{formData._id ? "Update Product" : "Add Product"}</button>
+              {formData._id && (
+                <button type="button" className="btn secondary-btn" onClick={resetForm}>Cancel</button>
+              )}
+            </div>
+          </form>
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/components/StoreDashboard.jsx
+++ b/src/components/StoreDashboard.jsx
@@ -78,48 +78,68 @@ function StoreDashboard() {
   };
 
   return (
-    <div>
-      <h2>Stores Dashboard</h2>
+    <div className="dashboard-grid">
+      <section className="dashboard-section">
+        <h2 className="section-title">All Stores</h2>
+        <div className="card">
+          {stores.length === 0 ? (
+            <p className="empty-state">No stores found.</p>
+          ) : (
+            <ul className="data-list">
+              {stores.map((s) => (
+                <li key={s._id} className="data-card">
+                  <div>
+                    <span className="item-title">{s.name}</span>
+                    <p className="item-meta">ID: {s.store_id} • Location: {s.location}</p>
+                  </div>
+                  <div className="actions">
+                    <button type="button" className="btn edit-btn" onClick={() => handleEdit(s)}>Edit</button>
+                    <button type="button" className="btn delete-btn" onClick={() => handleDelete(s._id)}>Delete</button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </section>
 
-      <form onSubmit={handleSubmit}>
-        <input
-          type="text"
-          name="store_id"
-          placeholder="Store ID"
-          value={form.store_id}
-          onChange={handleChange}
-          required
-        />
-        <input
-          type="text"
-          name="name"
-          placeholder="Store Name"
-          value={form.name}
-          onChange={handleChange}
-          required
-        />
-        <input
-          type="text"
-          name="location"
-          placeholder="Location"
-          value={form.location}
-          onChange={handleChange}
-          required
-        />
-        <button type="submit">{form._id ? "Update Store" : "Add Store"}</button>
-        {form._id && <button type="button" onClick={resetForm}>Cancel</button>}
-      </form>
-
-      <h3>All Stores</h3>
-      <ul>
-        {stores.map((s) => (
-          <li key={s._id}>
-            {s.store_id} — {s.name} ({s.location})
-            <button onClick={() => handleEdit(s)}>Edit</button>
-            <button onClick={() => handleDelete(s._id)}>Delete</button>
-          </li>
-        ))}
-      </ul>
+      <section className="dashboard-section">
+        <h2 className="section-title">{form._id ? "Edit Store" : "Add Store"}</h2>
+        <div className="card">
+          <form onSubmit={handleSubmit} className="form-grid">
+            <input
+              type="text"
+              name="store_id"
+              placeholder="Store ID"
+              value={form.store_id}
+              onChange={handleChange}
+              required
+            />
+            <input
+              type="text"
+              name="name"
+              placeholder="Store Name"
+              value={form.name}
+              onChange={handleChange}
+              required
+            />
+            <input
+              type="text"
+              name="location"
+              placeholder="Location"
+              value={form.location}
+              onChange={handleChange}
+              required
+            />
+            <div className="actions">
+              <button type="submit" className="btn primary-btn">{form._id ? "Update Store" : "Add Store"}</button>
+              {form._id && (
+                <button type="button" className="btn secondary-btn" onClick={resetForm}>Cancel</button>
+              )}
+            </div>
+          </form>
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/components/TransactionDashboard.jsx
+++ b/src/components/TransactionDashboard.jsx
@@ -104,67 +104,85 @@ function TransactionDashboard() {
   };
 
   return (
-    <div>
-      <h2>Transactions</h2>
-      {transactions.length === 0 ? (
-        <p>No transactions found.</p>
-      ) : (
-        <ul>
-          {transactions.map(t => (
-            <li key={t._id}>
-              {t.transaction_id} — Customer: {t.customer_id} — Total: {t.total}
-              <button onClick={() => handleEdit(t)}>Edit</button>
-              <button onClick={() => handleDelete(t._id)}>Delete</button>
-            </li>
-          ))}
-        </ul>
-      )}
+    <div className="dashboard-grid">
+      <section className="dashboard-section">
+        <h2 className="section-title">Recent Transactions</h2>
+        <div className="card">
+          {transactions.length === 0 ? (
+            <p className="empty-state">No transactions found.</p>
+          ) : (
+            <ul className="data-list">
+              {transactions.map(t => (
+                <li key={t._id} className="data-card">
+                  <div>
+                    <span className="item-title">{t.transaction_id}</span>
+                    <p className="item-meta">Customer: {t.customer_id}</p>
+                    <p className="item-meta">Total: Rs.{t.total}</p>
+                  </div>
+                  <div className="actions">
+                    <button type="button" className="btn edit-btn" onClick={() => handleEdit(t)}>Edit</button>
+                    <button type="button" className="btn delete-btn" onClick={() => handleDelete(t._id)}>Delete</button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </section>
 
-      <h3>{formData._id ? "Edit Transaction" : "Add Transaction"}</h3>
-      <form onSubmit={handleSubmit}>
-        <input
-          type="text"
-          name="transaction_id"
-          placeholder="Transaction ID"
-          value={formData.transaction_id}
-          onChange={handleChange}
-          required
-        />
-        <input
-          type="text"
-          name="customer_id"
-          placeholder="Customer ID"
-          value={formData.customer_id}
-          onChange={handleChange}
-          required
-        />
-        <input
-          type="text"
-          name="product_id"
-          placeholder="Product ID"
-          value={formData.product_id}
-          onChange={handleChange}
-          required
-        />
-        <input
-          type="number"
-          name="qty"
-          placeholder="Quantity"
-          value={formData.qty}
-          onChange={handleChange}
-          required
-        />
-        <input
-          type="number"
-          name="price"
-          placeholder="Price"
-          value={formData.price}
-          onChange={handleChange}
-          required
-        />
-        <button type="submit">{formData._id ? "Update Transaction" : "Add Transaction"}</button>
-        {formData._id && <button type="button" onClick={resetForm}>Cancel</button>}
-      </form>
+      <section className="dashboard-section">
+        <h2 className="section-title">{formData._id ? "Edit Transaction" : "Add Transaction"}</h2>
+        <div className="card">
+          <form onSubmit={handleSubmit} className="form-grid">
+            <input
+              type="text"
+              name="transaction_id"
+              placeholder="Transaction ID"
+              value={formData.transaction_id}
+              onChange={handleChange}
+              required
+            />
+            <input
+              type="text"
+              name="customer_id"
+              placeholder="Customer ID"
+              value={formData.customer_id}
+              onChange={handleChange}
+              required
+            />
+            <input
+              type="text"
+              name="product_id"
+              placeholder="Product ID"
+              value={formData.product_id}
+              onChange={handleChange}
+              required
+            />
+            <input
+              type="number"
+              name="qty"
+              placeholder="Quantity"
+              value={formData.qty}
+              onChange={handleChange}
+              required
+            />
+            <input
+              type="number"
+              name="price"
+              placeholder="Price"
+              value={formData.price}
+              onChange={handleChange}
+              required
+            />
+            <div className="actions">
+              <button type="submit" className="btn primary-btn">{formData._id ? "Update Transaction" : "Add Transaction"}</button>
+              {formData._id && (
+                <button type="button" className="btn secondary-btn" onClick={resetForm}>Cancel</button>
+              )}
+            </div>
+          </form>
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/pages/Analytics.jsx
+++ b/src/pages/Analytics.jsx
@@ -11,16 +11,31 @@ function Analytics() {
   }, []);
 
   return (
-    <div>
-      <h1>Analytics Dashboard</h1>
-      <h2>Top Spenders</h2>
-      <ul>
-        {topSpenders.map((s, i) => (
-          <li key={i}>
-            Customer {s._id} — Total Spent: Rs.{s.totalSpent}
-          </li>
-        ))}
-      </ul>
+    <div className="page-wrapper">
+      <header className="page-header">
+        <h1 className="page-title">Analytics Dashboard</h1>
+        <p className="page-subtitle">Review shopper trends and reward your top spenders.</p>
+      </header>
+
+      <section className="dashboard-section">
+        <h2 className="section-title">Top Spenders</h2>
+        <div className="card">
+          {topSpenders.length === 0 ? (
+            <p className="empty-state">No spending insights available yet.</p>
+          ) : (
+            <ul className="data-list">
+              {topSpenders.map((s, i) => (
+                <li key={i} className="data-card">
+                  <div>
+                    <span className="item-title">Customer {s._id}</span>
+                    <p className="item-meta">Total Spent: Rs.{s.totalSpent}</p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/pages/Customers.jsx
+++ b/src/pages/Customers.jsx
@@ -2,8 +2,11 @@ import CustomerDashboard from "../components/CustomerDashboard";
 
 function Customers() {
   return (
-    <div>
-      <h1>Customers</h1>
+    <div className="page-wrapper">
+      <header className="page-header">
+        <h1 className="page-title">Customers</h1>
+        <p className="page-subtitle">Manage loyalty members, household profiles, and preferences.</p>
+      </header>
       <CustomerDashboard />
     </div>
   );

--- a/src/pages/Offers.jsx
+++ b/src/pages/Offers.jsx
@@ -2,8 +2,11 @@ import OfferDashboard from "../components/OfferDashboard";
 
 function Offers() {
   return (
-    <div>
-      <h1>Offers</h1>
+    <div className="page-wrapper">
+      <header className="page-header">
+        <h1 className="page-title">Offers</h1>
+        <p className="page-subtitle">Plan timely promotions tailored for every loyalty tier.</p>
+      </header>
       <OfferDashboard />
     </div>
   );

--- a/src/pages/Products.jsx
+++ b/src/pages/Products.jsx
@@ -2,8 +2,11 @@ import ProductDashboard from "../components/ProductDashboard";
 
 function Products() {
   return (
-    <div>
-      <h1>Products</h1>
+    <div className="page-wrapper">
+      <header className="page-header">
+        <h1 className="page-title">Products</h1>
+        <p className="page-subtitle">Keep the Cargills catalogue fresh with accurate pricing and tagging.</p>
+      </header>
       <ProductDashboard />
     </div>
   );

--- a/src/pages/Stores.jsx
+++ b/src/pages/Stores.jsx
@@ -2,8 +2,11 @@ import StoreDashboard from "../components/StoreDashboard";
 
 function Stores() {
   return (
-    <div>
-      <h1>Stores</h1>
+    <div className="page-wrapper">
+      <header className="page-header">
+        <h1 className="page-title">Stores</h1>
+        <p className="page-subtitle">Track locations, formats, and neighborhood performance.</p>
+      </header>
       <StoreDashboard />
     </div>
   );

--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -2,8 +2,11 @@ import TransactionDashboard from "../components/TransactionDashboard";
 
 function Transactions() {
   return (
-    <div>
-      <h1>Transactions</h1>
+    <div className="page-wrapper">
+      <header className="page-header">
+        <h1 className="page-title">Transactions</h1>
+        <p className="page-subtitle">Audit purchases and keep shopper history up to date.</p>
+      </header>
       <TransactionDashboard />
     </div>
   );

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,353 @@
+:root {
+  --primary-red: #d32f2f;
+  --primary-red-dark: #9a0007;
+  --secondary-bg: #f6f7fb;
+  --card-bg: #ffffff;
+  --border-light: #e5e7eb;
+  --text-primary: #1f2933;
+  --text-secondary: #4b5563;
+  --accent-yellow: #f9a825;
+  --accent-yellow-dark: #c17900;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  background: var(--secondary-bg);
+  color: var(--text-primary);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.app-container {
+  display: flex;
+  min-height: 100vh;
+  background: var(--secondary-bg);
+}
+
+.sidebar {
+  width: 260px;
+  background: var(--card-bg);
+  border-right: 4px solid var(--primary-red);
+  padding: 2rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.08);
+  position: sticky;
+  top: 0;
+  height: 100vh;
+}
+
+.sidebar-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: var(--primary-red);
+  text-align: center;
+  margin: 0;
+}
+
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: 0.75rem;
+}
+
+.nav-link {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  background: #f5f5f5;
+  border: 1px solid transparent;
+  transition: all 0.2s ease-in-out;
+}
+
+.nav-link:hover {
+  border-color: var(--primary-red);
+  color: var(--primary-red);
+  background: #fff5f5;
+  transform: translateX(4px);
+}
+
+.nav-link.active {
+  background: var(--primary-red);
+  color: #ffffff;
+  box-shadow: 0 10px 25px rgba(211, 47, 47, 0.3);
+}
+
+.main-content {
+  flex: 1;
+  padding: 3rem;
+  overflow-y: auto;
+}
+
+.page-wrapper {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.page-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.page-title {
+  font-size: 2.25rem;
+  margin: 0;
+  font-weight: 700;
+  color: var(--primary-red);
+}
+
+.page-subtitle {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 1rem;
+}
+
+.dashboard-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.dashboard-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.section-title {
+  font-size: 1.35rem;
+  margin: 0;
+  font-weight: 700;
+  color: var(--text-primary);
+  border-bottom: 3px solid var(--primary-red);
+  padding-bottom: 0.5rem;
+  display: inline-block;
+}
+
+.card {
+  background: var(--card-bg);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.08);
+  border: 1px solid rgba(211, 47, 47, 0.08);
+}
+
+.data-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.data-card {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  background: #fff5f5;
+  border: 1px solid rgba(211, 47, 47, 0.18);
+  border-radius: 0.85rem;
+  padding: 1rem 1.25rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.data-card .item-title {
+  font-weight: 700;
+  color: var(--primary-red);
+}
+
+.data-card .item-meta {
+  color: var(--text-secondary);
+  font-size: 0.92rem;
+  margin: 0.35rem 0 0;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.empty-state {
+  margin: 0;
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.form-grid input,
+.form-grid select,
+.form-grid textarea {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 0.85rem;
+  border: 1px solid #d1d5db;
+  background: #ffffff;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-grid input:focus,
+.form-grid select:focus,
+.form-grid textarea:focus {
+  border-color: var(--primary-red);
+  box-shadow: 0 0 0 3px rgba(211, 47, 47, 0.18);
+  outline: none;
+}
+
+.btn {
+  border: none;
+  border-radius: 0.85rem;
+  padding: 0.65rem 1.25rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.1);
+}
+
+.primary-btn {
+  background: var(--primary-red);
+  color: #ffffff;
+}
+
+.primary-btn:hover {
+  background: var(--primary-red-dark);
+}
+
+.secondary-btn {
+  background: #ffffff;
+  color: var(--primary-red);
+  border: 1px solid var(--primary-red);
+}
+
+.secondary-btn:hover {
+  background: #fff0f0;
+}
+
+.edit-btn {
+  background: var(--accent-yellow);
+  color: #4a3000;
+}
+
+.edit-btn:hover {
+  background: var(--accent-yellow-dark);
+  color: #fff8e1;
+}
+
+.delete-btn {
+  background: var(--primary-red);
+  color: #ffffff;
+}
+
+.delete-btn:hover {
+  background: var(--primary-red-dark);
+}
+
+.table-card {
+  overflow: hidden;
+  border-radius: 1rem;
+  border: 1px solid rgba(211, 47, 47, 0.12);
+}
+
+.table-card table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--card-bg);
+}
+
+.table-card th {
+  background: rgba(211, 47, 47, 0.08);
+  color: var(--primary-red);
+  text-align: left;
+  padding: 0.85rem 1rem;
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
+.table-card td {
+  padding: 0.75rem 1rem;
+  border-top: 1px solid rgba(211, 47, 47, 0.1);
+  color: var(--text-secondary);
+}
+
+@media (max-width: 960px) {
+  .sidebar {
+    position: relative;
+    width: 100%;
+    height: auto;
+    flex-direction: row;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  .sidebar-nav {
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .nav-link {
+    flex: 1 1 140px;
+    text-align: center;
+  }
+
+  .main-content {
+    padding: 2rem 1.5rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .page-title {
+    font-size: 1.75rem;
+  }
+
+  .card {
+    padding: 1.25rem;
+  }
+}
+
+.h-12 {
+  height: 3rem;
+}
+
+.mx-auto {
+  margin-left: auto;
+  margin-right: auto;
+  display: block;
+}
+
+.my-4 {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
## Summary
- add a sidebar layout with a logo placeholder and navigation that uses the Cargills red brand color
- restyle analytics and CRUD dashboards with red highlights, accent buttons, and updated section headers
- centralize theme variables and component styling in a shared stylesheet

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68de2f7ecf008323b15527be0b75fd3a