### PR TITLE
Style analytics page with Cargills red theme

### DIFF
--- a/src/pages/Analytics.jsx
+++ b/src/pages/Analytics.jsx
@@ -62,158 +62,275 @@ function AnalyticsPage() {
     }
   };
 
-  const colors = ["#D32F2F", "#FF5252", "#C62828", "#FF7043", "#E53935"];
+  const primaryRed = "#D32F2F";
+  const colors = [primaryRed];
 
   return (
-    <div className="analytics-page">
-      <h1>Cargills Retail Analytics Dashboard</h1>
+    <div className="analytics-page min-h-screen bg-[#F9FAFB] px-4 py-8 md:px-10 md:py-12 space-y-10">
+      <h1 className="text-3xl font-bold text-center text-[#D32F2F] tracking-tight">Cargills Retail Analytics Dashboard</h1>
 
       {/* 1. Loyalty Tier Distribution */}
-      <h2>Loyalty Tier Distribution</h2>
-      <ResponsiveContainer width="100%" height={300}>
-        <PieChart>
-          <Pie data={tierCount} dataKey="count" nameKey="_id" outerRadius={120} label>
-            {tierCount.map((entry, i) => <Cell key={i} fill={colors[i % colors.length]} />)}
-          </Pie>
-          <Tooltip />
-          <Legend />
-        </PieChart>
-      </ResponsiveContainer>
+      <section className="bg-white rounded-2xl shadow-lg p-6 space-y-6">
+        <h2 className="text-2xl font-semibold text-gray-900 border-b-4 border-[#D32F2F] inline-block pb-1">Loyalty Tier Distribution</h2>
+        <div className="h-72">
+          <ResponsiveContainer width="100%" height="100%">
+            <PieChart>
+              <Pie data={tierCount} dataKey="count" nameKey="_id" outerRadius={120} label>
+                {tierCount.map((entry, i) => (
+                  <Cell key={i} fill={colors[i % colors.length]} />
+                ))}
+              </Pie>
+              <Tooltip contentStyle={{ borderRadius: "0.75rem", borderColor: primaryRed }} />
+              <Legend wrapperStyle={{ color: "#374151" }} />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+      </section>
 
       {/* 2. Total Sales by Store */}
-      <h2>Total Sales by Store</h2>
-      <ResponsiveContainer width="100%" height={300}>
-        <BarChart data={salesByStore}>
-          <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="_id" />
-          <YAxis />
-          <Tooltip />
-          <Legend />
-          <Bar dataKey="totalSales" fill="#D32F2F" />
-        </BarChart>
-      </ResponsiveContainer>
+      <section className="bg-white rounded-2xl shadow-lg p-6 space-y-6">
+        <h2 className="text-2xl font-semibold text-gray-900 border-b-4 border-[#D32F2F] inline-block pb-1">Total Sales by Store</h2>
+        <div className="h-72">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={salesByStore}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#F3F4F6" />
+              <XAxis dataKey="_id" stroke="#4B5563" />
+              <YAxis stroke="#4B5563" />
+              <Tooltip contentStyle={{ borderRadius: "0.75rem", borderColor: primaryRed }} />
+              <Legend wrapperStyle={{ color: "#374151" }} />
+              <Bar dataKey="totalSales" fill={primaryRed} radius={[8, 8, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </section>
 
       {/* 3. Top 5 Best-Selling Products */}
-      <h2>Top 5 Best-Selling Products</h2>
-      <ResponsiveContainer width="100%" height={300}>
-        <BarChart data={topProducts}>
-          <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="_id" />
-          <YAxis />
-          <Tooltip />
-          <Legend />
-          <Bar dataKey="totalQty" fill="#FF7043" />
-        </BarChart>
-      </ResponsiveContainer>
+      <section className="bg-white rounded-2xl shadow-lg p-6 space-y-6">
+        <h2 className="text-2xl font-semibold text-gray-900 border-b-4 border-[#D32F2F] inline-block pb-1">Top 5 Best-Selling Products</h2>
+        <div className="h-72">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={topProducts}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#F3F4F6" />
+              <XAxis dataKey="_id" stroke="#4B5563" />
+              <YAxis stroke="#4B5563" />
+              <Tooltip contentStyle={{ borderRadius: "0.75rem", borderColor: primaryRed }} />
+              <Legend wrapperStyle={{ color: "#374151" }} />
+              <Bar dataKey="totalQty" fill={primaryRed} radius={[8, 8, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </section>
 
       {/* 4. Avg Basket Size by Tier */}
-      <h2>Average Basket Size by Loyalty Tier</h2>
-      <table border="1" cellPadding="8">
-        <thead>
-          <tr><th>Loyalty Tier</th><th>Avg Items</th></tr>
-        </thead>
-        <tbody>
-          {avgBasket.map((b, i) => (
-            <tr key={i}><td>{b._id}</td><td>{b.avgItems.toFixed(2)}</td></tr>
-          ))}
-        </tbody>
-      </table>
+      <section className="bg-white rounded-2xl shadow-lg p-6 space-y-6">
+        <h2 className="text-2xl font-semibold text-gray-900 border-b-4 border-[#D32F2F] inline-block pb-1">Average Basket Size by Loyalty Tier</h2>
+        <div className="overflow-x-auto">
+          <table className="min-w-full border-collapse">
+            <thead className="bg-[#D32F2F] text-white">
+              <tr>
+                <th className="px-4 py-3 text-left font-semibold">Loyalty Tier</th>
+                <th className="px-4 py-3 text-left font-semibold">Avg Items</th>
+              </tr>
+            </thead>
+            <tbody className="text-gray-700">
+              {avgBasket.map((b, i) => (
+                <tr
+                  key={i}
+                  className="odd:bg-white even:bg-[#FDECEC] hover:bg-[#F8C5C5] transition-colors"
+                >
+                  <td className="px-4 py-3 font-medium">{b._id}</td>
+                  <td className="px-4 py-3">{b.avgItems.toFixed(2)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
 
       {/* 5. Top Spending Customers */}
-      <h2>Top Spending Customers</h2>
-      <table border="1" cellPadding="8">
-        <thead>
-          <tr><th>Customer</th><th>Total Spend</th></tr>
-        </thead>
-        <tbody>
-          {topSpenders.map((s, i) => (
-            <tr key={i}><td>{s._id}</td><td>{s.totalSpend}</td></tr>
-          ))}
-        </tbody>
-      </table>
+      <section className="bg-white rounded-2xl shadow-lg p-6 space-y-6">
+        <h2 className="text-2xl font-semibold text-gray-900 border-b-4 border-[#D32F2F] inline-block pb-1">Top Spending Customers</h2>
+        <div className="overflow-x-auto">
+          <table className="min-w-full border-collapse">
+            <thead className="bg-[#D32F2F] text-white">
+              <tr>
+                <th className="px-4 py-3 text-left font-semibold">Customer</th>
+                <th className="px-4 py-3 text-left font-semibold">Total Spend</th>
+              </tr>
+            </thead>
+            <tbody className="text-gray-700">
+              {topSpenders.map((s, i) => (
+                <tr
+                  key={i}
+                  className="odd:bg-white even:bg-[#FDECEC] hover:bg-[#F8C5C5] transition-colors"
+                >
+                  <td className="px-4 py-3 font-medium">{s._id}</td>
+                  <td className="px-4 py-3">{s.totalSpend}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
 
       {/* 6. Category Spend per Customer */}
-      <h2>Category Spend per Customer</h2>
-      <table border="1" cellPadding="8">
-        <thead>
-          <tr><th>Customer</th><th>Category</th><th>Spend</th></tr>
-        </thead>
-        <tbody>
-          {categorySpend.slice(0, 20).map((c, i) => (
-            <tr key={i}><td>{c._id.customer}</td><td>{c._id.category}</td><td>{c.spend}</td></tr>
-          ))}
-        </tbody>
-      </table>
+      <section className="bg-white rounded-2xl shadow-lg p-6 space-y-6">
+        <h2 className="text-2xl font-semibold text-gray-900 border-b-4 border-[#D32F2F] inline-block pb-1">Category Spend per Customer</h2>
+        <div className="overflow-x-auto">
+          <table className="min-w-full border-collapse">
+            <thead className="bg-[#D32F2F] text-white">
+              <tr>
+                <th className="px-4 py-3 text-left font-semibold">Customer</th>
+                <th className="px-4 py-3 text-left font-semibold">Category</th>
+                <th className="px-4 py-3 text-left font-semibold">Spend</th>
+              </tr>
+            </thead>
+            <tbody className="text-gray-700">
+              {categorySpend.slice(0, 20).map((c, i) => (
+                <tr
+                  key={i}
+                  className="odd:bg-white even:bg-[#FDECEC] hover:bg-[#F8C5C5] transition-colors"
+                >
+                  <td className="px-4 py-3 font-medium">{c._id.customer}</td>
+                  <td className="px-4 py-3">{c._id.category}</td>
+                  <td className="px-4 py-3">{c.spend}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
 
       {/* 7. Store-Level Category Demand */}
-      <h2>Store-Level Category Demand</h2>
-      <table border="1" cellPadding="8">
-        <thead>
-          <tr><th>Store</th><th>Category</th><th>Total Qty</th></tr>
-        </thead>
-        <tbody>
-          {storeCategory.slice(0, 20).map((sc, i) => (
-            <tr key={i}><td>{sc._id.store}</td><td>{sc._id.category}</td><td>{sc.totalQty}</td></tr>
-          ))}
-        </tbody>
-      </table>
+      <section className="bg-white rounded-2xl shadow-lg p-6 space-y-6">
+        <h2 className="text-2xl font-semibold text-gray-900 border-b-4 border-[#D32F2F] inline-block pb-1">Store-Level Category Demand</h2>
+        <div className="overflow-x-auto">
+          <table className="min-w-full border-collapse">
+            <thead className="bg-[#D32F2F] text-white">
+              <tr>
+                <th className="px-4 py-3 text-left font-semibold">Store</th>
+                <th className="px-4 py-3 text-left font-semibold">Category</th>
+                <th className="px-4 py-3 text-left font-semibold">Total Qty</th>
+              </tr>
+            </thead>
+            <tbody className="text-gray-700">
+              {storeCategory.slice(0, 20).map((sc, i) => (
+                <tr
+                  key={i}
+                  className="odd:bg-white even:bg-[#FDECEC] hover:bg-[#F8C5C5] transition-colors"
+                >
+                  <td className="px-4 py-3 font-medium">{sc._id.store}</td>
+                  <td className="px-4 py-3">{sc._id.category}</td>
+                  <td className="px-4 py-3">{sc.totalQty}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
 
       {/* 8. Churn Risk Customers */}
-      <h2>Churn Risk Customers (No Purchase in 60 Days)</h2>
-      <ul>
-        {churnRisk.map((c, i) => <li key={i}>{c._id} — Last Purchase: {new Date(c.lastPurchase).toDateString()}</li>)}
-      </ul>
+      <section className="bg-white rounded-2xl shadow-lg p-6 space-y-6">
+        <h2 className="text-2xl font-semibold text-gray-900 border-b-4 border-[#D32F2F] inline-block pb-1">Churn Risk Customers (No Purchase in 60 Days)</h2>
+        <ul className="space-y-3 text-gray-700">
+          {churnRisk.map((c, i) => (
+            <li
+              key={i}
+              className="flex flex-col gap-1 rounded-xl bg-[#FDECEC] px-4 py-3 border-l-4 border-[#D32F2F] shadow-sm hover:shadow-md transition-shadow"
+            >
+              <span className="font-semibold text-gray-900">{c._id}</span>
+              <span className="text-sm text-gray-600">Last Purchase: {new Date(c.lastPurchase).toDateString()}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
 
       {/* 9. Dairy Buyers (Simple Cross-Sell Proxy) */}
-      <h2>Customers Who Bought Dairy Products</h2>
-      <ul>
-        {dairyBuyers.map((d, i) => (
-          <li key={i}>{d.customer_id} — Transaction {d.transaction_id}</li>
-        ))}
-      </ul>
+      <section className="bg-white rounded-2xl shadow-lg p-6 space-y-6">
+        <h2 className="text-2xl font-semibold text-gray-900 border-b-4 border-[#D32F2F] inline-block pb-1">Customers Who Bought Dairy Products</h2>
+        <ul className="space-y-3 text-gray-700">
+          {dairyBuyers.map((d, i) => (
+            <li
+              key={i}
+              className="flex flex-col gap-1 rounded-xl bg-[#FDECEC] px-4 py-3 border-l-4 border-[#D32F2F] shadow-sm hover:shadow-md transition-shadow"
+            >
+              <span className="font-semibold text-gray-900">{d.customer_id}</span>
+              <span className="text-sm text-gray-600">Transaction {d.transaction_id}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
 
       {/* 10. Price Sensitivity by Tier */}
-      <h2>Price Sensitivity by Loyalty Tier</h2>
-      <table border="1" cellPadding="8">
-        <thead>
-          <tr><th>Loyalty Tier</th><th>Avg Price per Item</th></tr>
-        </thead>
-        <tbody>
-          {priceSensitivity.map((p, i) => (
-            <tr key={i}><td>{p._id}</td><td>{p.avgPrice.toFixed(2)}</td></tr>
-          ))}
-        </tbody>
-      </table>
+      <section className="bg-white rounded-2xl shadow-lg p-6 space-y-6">
+        <h2 className="text-2xl font-semibold text-gray-900 border-b-4 border-[#D32F2F] inline-block pb-1">Price Sensitivity by Loyalty Tier</h2>
+        <div className="overflow-x-auto">
+          <table className="min-w-full border-collapse">
+            <thead className="bg-[#D32F2F] text-white">
+              <tr>
+                <th className="px-4 py-3 text-left font-semibold">Loyalty Tier</th>
+                <th className="px-4 py-3 text-left font-semibold">Avg Price per Item</th>
+              </tr>
+            </thead>
+            <tbody className="text-gray-700">
+              {priceSensitivity.map((p, i) => (
+                <tr
+                  key={i}
+                  className="odd:bg-white even:bg-[#FDECEC] hover:bg-[#F8C5C5] transition-colors"
+                >
+                  <td className="px-4 py-3 font-medium">{p._id}</td>
+                  <td className="px-4 py-3">{p.avgPrice.toFixed(2)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
 
       {/* 11. Household Size vs Basket Value */}
-      <h2>Household Size vs Basket Value</h2>
-      <ResponsiveContainer width="100%" height={300}>
-        <BarChart data={householdBasket}>
-          <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="_id" />
-          <YAxis />
-          <Tooltip />
-          <Legend />
-          <Bar dataKey="avgSpend" fill="#C62828" />
-        </BarChart>
-      </ResponsiveContainer>
+      <section className="bg-white rounded-2xl shadow-lg p-6 space-y-6">
+        <h2 className="text-2xl font-semibold text-gray-900 border-b-4 border-[#D32F2F] inline-block pb-1">Household Size vs Basket Value</h2>
+        <div className="h-72">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={householdBasket}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#F3F4F6" />
+              <XAxis dataKey="_id" stroke="#4B5563" />
+              <YAxis stroke="#4B5563" />
+              <Tooltip contentStyle={{ borderRadius: "0.75rem", borderColor: primaryRed }} />
+              <Legend wrapperStyle={{ color: "#374151" }} />
+              <Bar dataKey="avgSpend" fill={primaryRed} radius={[8, 8, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </section>
 
       {/* 12. Customer Lifetime Value */}
-      <h2>Customer Lifetime Value (Top 10)</h2>
-      <table border="1" cellPadding="8">
-        <thead>
-          <tr><th>Customer</th><th>Lifetime Spend</th><th>Transactions</th></tr>
-        </thead>
-        <tbody>
-          {clv.slice(0, 10).map((c, i) => (
-            <tr key={i}>
-              <td>{c._id}</td>
-              <td>{c.lifetimeSpend}</td>
-              <td>{c.txCount}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <section className="bg-white rounded-2xl shadow-lg p-6 space-y-6">
+        <h2 className="text-2xl font-semibold text-gray-900 border-b-4 border-[#D32F2F] inline-block pb-1">Customer Lifetime Value (Top 10)</h2>
+        <div className="overflow-x-auto">
+          <table className="min-w-full border-collapse">
+            <thead className="bg-[#D32F2F] text-white">
+              <tr>
+                <th className="px-4 py-3 text-left font-semibold">Customer</th>
+                <th className="px-4 py-3 text-left font-semibold">Lifetime Spend</th>
+                <th className="px-4 py-3 text-left font-semibold">Transactions</th>
+              </tr>
+            </thead>
+            <tbody className="text-gray-700">
+              {clv.slice(0, 10).map((c, i) => (
+                <tr
+                  key={i}
+                  className="odd:bg-white even:bg-[#FDECEC] hover:bg-[#F8C5C5] transition-colors"
+                >
+                  <td className="px-4 py-3 font-medium">{c._id}</td>
+                  <td className="px-4 py-3">{c.lifetimeSpend}</td>
+                  <td className="px-4 py-3">{c.txCount}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- restyle the analytics dashboard with Tailwind-inspired cards and a cohesive Cargills red theme
- update charts, tables, and list sections to share consistent typography, spacing, and accent colors

## Testing
- npm run build *(fails: Rollup failed to resolve import "recharts")*

------
https://chatgpt.com/codex/tasks/task_e_68de9739bfec83238a4aadff3a2cc073